### PR TITLE
[FIX][106] Update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,14 +40,14 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0-beta5" }
-cosmwasm-storage = { version = "1.0.0-beta5" }
-cw-storage-plus = "0.12"
-cw2 = "0.12"
+cosmwasm-std = { version = "1.0.0-beta6" }
+cosmwasm-storage = { version = "1.0.0-beta6" }
+cw-storage-plus = "0.13"
+cw2 = "0.13"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta5" }
-cw-multi-test = "0.12"
+cosmwasm-schema = { version = "1.0.0-beta6" }
+cw-multi-test = "0.13"


### PR DESCRIPTION
Changed API in updated dependencies lead to failing (unit) tests.
Fixed by updating crate versions.

https://github.com/CosmWasm/cosmwasm/pull/1232
https://github.com/InterWasm/cw-template/issues/106