### PR TITLE
fix test on mock_dependecies

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -84,7 +84,7 @@ mod tests {
 
     #[test]
     fn proper_initialization() {
-        let mut deps = mock_dependencies(&coins(2, "token"));
+        let mut deps = mock_dependencies();
 
         let msg = InstantiateMsg { count: 17 };
         let info = mock_info("creator", &coins(1000, "earth"));
@@ -101,7 +101,7 @@ mod tests {
 
     #[test]
     fn increment() {
-        let mut deps = mock_dependencies(&coins(2, "token"));
+        let mut deps = mock_dependencies();
 
         let msg = InstantiateMsg { count: 17 };
         let info = mock_info("creator", &coins(2, "token"));
@@ -120,7 +120,7 @@ mod tests {
 
     #[test]
     fn reset() {
-        let mut deps = mock_dependencies(&coins(2, "token"));
+        let mut deps = mock_dependencies();
 
         let msg = InstantiateMsg { count: 17 };
         let info = mock_info("creator", &coins(2, "token"));


### PR DESCRIPTION
This PR solves issue #119 

There're tow solutions here.
1. use `mock_dependencies_with_balance`
2. use current `mock_dependencies` by eliminate the argument 

I didn't know what coder wanted it to behave.
But, observing the situation, I thought solution 2 is suitable for this.