### PR TITLE
Support cosmwasm-typescript-gen convention

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response,
 use cw2::set_contract_version;
 
 use crate::error::ContractError;
-use crate::msg::{CountResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
+use crate::msg::{ExecuteMsg, GetCountResponse, InstantiateMsg, QueryMsg};
 use crate::state::{State, STATE};
 
 // version info for migration info
@@ -71,9 +71,9 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     }
 }
 
-fn query_count(deps: Deps) -> StdResult<CountResponse> {
+fn query_count(deps: Deps) -> StdResult<GetCountResponse> {
     let state = STATE.load(deps.storage)?;
-    Ok(CountResponse { count: state.count })
+    Ok(GetCountResponse { count: state.count })
 }
 
 #[cfg(test)]
@@ -95,7 +95,7 @@ mod tests {
 
         // it worked, let's query the state
         let res = query(deps.as_ref(), mock_env(), QueryMsg::GetCount {}).unwrap();
-        let value: CountResponse = from_binary(&res).unwrap();
+        let value: GetCountResponse = from_binary(&res).unwrap();
         assert_eq!(17, value.count);
     }
 
@@ -114,7 +114,7 @@ mod tests {
 
         // should increase counter by 1
         let res = query(deps.as_ref(), mock_env(), QueryMsg::GetCount {}).unwrap();
-        let value: CountResponse = from_binary(&res).unwrap();
+        let value: GetCountResponse = from_binary(&res).unwrap();
         assert_eq!(18, value.count);
     }
 
@@ -142,7 +142,7 @@ mod tests {
 
         // should now be 5
         let res = query(deps.as_ref(), mock_env(), QueryMsg::GetCount {}).unwrap();
-        let value: CountResponse = from_binary(&res).unwrap();
+        let value: GetCountResponse = from_binary(&res).unwrap();
         assert_eq!(5, value.count);
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{
     to_binary, Addr, CosmosMsg, CustomQuery, Querier, QuerierWrapper, StdResult, WasmMsg, WasmQuery,
 };
 
-use crate::msg::{CountResponse, ExecuteMsg, QueryMsg};
+use crate::msg::{ExecuteMsg, GetCountResponse, QueryMsg};
 
 /// CwTemplateContract is a wrapper around Addr that provides a lot of helpers
 /// for working with this.
@@ -28,7 +28,7 @@ impl CwTemplateContract {
     }
 
     /// Get Count
-    pub fn count<Q, T, CQ>(&self, querier: &Q) -> StdResult<CountResponse>
+    pub fn count<Q, T, CQ>(&self, querier: &Q) -> StdResult<GetCountResponse>
     where
         Q: Querier,
         T: Into<String>,
@@ -40,7 +40,7 @@ impl CwTemplateContract {
             msg: to_binary(&msg)?,
         }
         .into();
-        let res: CountResponse = QuerierWrapper::<CQ>::new(querier).query(&query)?;
+        let res: GetCountResponse = QuerierWrapper::<CQ>::new(querier).query(&query)?;
         Ok(res)
     }
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -22,6 +22,6 @@ pub enum QueryMsg {
 
 // We define a custom struct for each query response
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct CountResponse {
+pub struct GetCountResponse {
     pub count: i32,
 }


### PR DESCRIPTION


[cosmwasm-typescript-gen](https://github.com/CosmWasm/cosmwasm-typescript-gen) assumes naming convention of query message and response to be `{{MsgName}}` and `{{MsgName}}Response`, so I am renaming them to match the convention.